### PR TITLE
Fix: Remove reference to repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,6 @@
             "email": "daniel@dantleech.com"
         }
     ],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/microsoft/tolerant-php-parser"
-        }
-    ],
     "require": {
         "microsoft/tolerant-php-parser": "dev-master",
         "jetbrains/phpstorm-stubs": "dev-master",


### PR DESCRIPTION
This PR

* [x] removes a reference to the repository for `microsoft/tolerant-php-parser` as it is available via packagist

💁‍♂️ For reference, see https://packagist.org/packages/microsoft/tolerant-php-parser.