### PR TITLE
Fix: Use phpunit as installed with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ cache:
 before_script:
   - composer install
 
-script: 
-  - phpunit
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] uses `phpunit` as installed with `composer` on Travis