### PR TITLE
Added PHPBench benchmarks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ before_script:
 
 script:
   - vendor/bin/phpunit
+  - vendor/bin/phpbench run --report=aggregate --progress=travis

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "symfony/filesystem": "^3.3",
-        "phpbench/phpbench": "^1.0@dev"
+        "phpbench/phpbench": "^0.13.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "symfony/filesystem": "^3.3"
+        "symfony/filesystem": "^3.3",
+        "phpbench/phpbench": "^1.0@dev"
     },
     "autoload": {
         "psr-4": {

--- a/lib/SourceCodeLocator/ComposerSourceLocator.php
+++ b/lib/SourceCodeLocator/ComposerSourceLocator.php
@@ -22,7 +22,7 @@ class ComposerSourceLocator implements SourceCodeLocator
      */
     public function locate(ClassName $className): SourceCode
     {
-        $path = $this->classLoader->findFile($className->getFqn());
+        $path = $this->classLoader->findFile((string) $className);
 
         if (false === $path) {
             throw new SourceNotFound(sprintf(
@@ -31,6 +31,6 @@ class ComposerSourceLocator implements SourceCodeLocator
             ));
         }
 
-        return SourceCode::fromFilepath($path);
+        return SourceCode::fromPath($path);
     }
 }

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,4 @@
+{
+    "bootstrap": "vendor/autoload.php",
+    "path": "tests/Benchmarks"
+}

--- a/tests/Benchmarks/BaseBenchCase.php
+++ b/tests/Benchmarks/BaseBenchCase.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+use Phpactor\WorseReflection\SourceCodeLocator\ComposerSourceLocator;
+use Phpactor\WorseReflection\Reflector;
+
+abstract class BaseBenchCase
+{
+    public function getReflector(): Reflector
+    {
+        $sourceLocator = new ComposerSourceLocator(include(__DIR__ . '/../../vendor/autoload.php'));
+        return Reflector::create($sourceLocator);
+    }
+}

--- a/tests/Benchmarks/Examples/MethodClass.php
+++ b/tests/Benchmarks/Examples/MethodClass.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks\Examples;
+
+class MethodClass
+{
+    public function methodNoReturnType()
+    {
+    }
+
+    public function methodWithReturnType(): MethodClass
+    {
+    }
+
+    /**
+     * @return MethodClass
+     */
+    public function methodWithDocblockReturnType()
+    {
+    }
+}

--- a/tests/Benchmarks/Examples/PropertyClass.php
+++ b/tests/Benchmarks/Examples/PropertyClass.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks\Examples;
+
+class PropertyClass
+{
+    public $noType;
+
+    /**
+     * @var MethodClass
+     */
+    public $withType;
+}

--- a/tests/Benchmarks/PhpUnitReflectClassBench.php
+++ b/tests/Benchmarks/PhpUnitReflectClassBench.php
@@ -32,6 +32,7 @@ class PhpUnitReflectClassBench extends BaseBenchCase
         /** @var $method ReflectionMethod */
         foreach ($class->methods() as $method) {
             foreach ($method->parameters() as $parameter) {
+                $method->returnType();
             }
         }
 

--- a/tests/Benchmarks/PhpUnitReflectClassBench.php
+++ b/tests/Benchmarks/PhpUnitReflectClassBench.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\WorseReflection\ClassName;
+use Phpactor\WorseReflection\Reflection\ReflectionMethod;
+
+/**
+ * @Iterations(4)
+ * @Revs(10)
+ * @OutputTimeUnit("milliseconds", precision=2)
+ */
+class PhpUnitReflectClassBench extends BaseBenchCase
+{
+
+    /**
+     * @Subject()
+     */
+    public function test_case()
+    {
+        $class = $this->getReflector()->reflectClass(ClassName::fromString(TestCase::class));
+    }
+
+    /**
+     * @Subject()
+     */
+    public function test_case_methods_and_properties()
+    {
+        $class = $this->getReflector()->reflectClass(ClassName::fromString(TestCase::class));
+
+        /** @var $method ReflectionMethod */
+        foreach ($class->methods() as $method) {
+            foreach ($method->parameters() as $parameter) {
+            }
+        }
+
+        foreach ($class->properties() as $property) {
+            $property->type();
+        }
+    }
+}

--- a/tests/Benchmarks/ReflectMethodBench.php
+++ b/tests/Benchmarks/ReflectMethodBench.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\WorseReflection\ClassName;
+use Phpactor\WorseReflection\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Reflector;
+use Phpactor\WorseReflection\Tests\Benchmarks\Examples\MethodClass;
+use Phpactor\WorseReflection\Reflection\ReflectionClass;
+
+/**
+ * @Iterations(10)
+ * @Revs(30)
+ * @OutputTimeUnit("milliseconds", precision=2)
+ */
+class ReflectMethodBench extends BaseBenchCase
+{
+    /**
+     * @var ReflectionClass
+     */
+    private $class;
+
+    public function before()
+    {
+        $this->class = $this->getReflector()->reflectClass(ClassName::fromString(MethodClass::class));
+    }
+
+    /**
+     * @Subject()
+     * @BeforeMethods({"before"})
+     */
+    public function method()
+    {
+        $this->class->methods()->get('methodNoReturnType');
+    }
+
+    /**
+     * @Subject()
+     * @BeforeMethods({"before"})
+     */
+    public function method_return_type()
+    {
+        $this->class->methods()->get('methodWithReturnType')->returnType();
+    }
+
+    /**
+     * @Subject()
+     * @BeforeMethods({"before"})
+     */
+    public function method_inferred_return_type()
+    {
+        $this->class->methods()->get('methodWithDocblockReturnType')->inferredReturnType();
+    }
+}
+

--- a/tests/Benchmarks/ReflectPropertyBench.php
+++ b/tests/Benchmarks/ReflectPropertyBench.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Benchmarks;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\WorseReflection\ClassName;
+use Phpactor\WorseReflection\Reflection\ReflectionMethod;
+use Phpactor\WorseReflection\Reflector;
+use Phpactor\WorseReflection\Tests\Benchmarks\Examples\PropertyClass;
+use Phpactor\WorseReflection\Reflection\ReflectionClass;
+
+/**
+ * @Iterations(10)
+ * @Revs(30)
+ * @OutputTimeUnit("milliseconds", precision=2)
+ */
+class ReflectPropertyBench extends BaseBenchCase
+{
+    /**
+     * @var ReflectionClass
+     */
+    private $class;
+
+    public function before()
+    {
+        $this->class = $this->getReflector()->reflectClass(ClassName::fromString(PropertyClass::class));
+    }
+
+    /**
+     * @Subject()
+     * @BeforeMethods({"before"})
+     */
+    public function property()
+    {
+        $this->class->properties()->get('noType');
+    }
+
+    /**
+     * @Subject()
+     * @BeforeMethods({"before"})
+     */
+    public function property_return_type()
+    {
+        $this->class->properties()->get('withType')->type();
+    }
+}
+


### PR DESCRIPTION
Include PHPBench benchmarks to help track performance regressions.

```bash
PhpBench 0.14-dev (@git_version@). Running benchmarks.
Using configuration file: /home/daniel/www/phpactor/worse-reflection/phpbench.json

\Phpactor\WorseReflection\Tests\Benchmarks\PhpUnitReflectClassBench

    test_case                      I4 P0        [μ Mo]/r: 60.33 59.88 (ms)      [μSD μRSD]/r: 0.854ms 1.41%
    test_case_methods_and_properties I4 P0      [μ Mo]/r: 155.35 154.35 (ms)    [μSD μRSD]/r: 1.597ms 1.03%

\Phpactor\WorseReflection\Tests\Benchmarks\ReflectPropertyBench

    property                       I10 P0       [μ Mo]/r: 0.03 0.03 (ms)        [μSD μRSD]/r: 0.002ms 5.74%
    property_return_type           I10 P0       [μ Mo]/r: 0.08 0.08 (ms)        [μSD μRSD]/r: 0.003ms 3.90%

\Phpactor\WorseReflection\Tests\Benchmarks\ReflectMethodBench

    method                         I10 P0       [μ Mo]/r: 0.03 0.03 (ms)        [μSD μRSD]/r: 0.003ms 9.04%
    method_return_type             I10 P0       [μ Mo]/r: 0.10 0.09 (ms)        [μSD μRSD]/r: 0.003ms 2.68%
    method_inferred_return_type    I10 P0       [μ Mo]/r: 0.12 0.11 (ms)        [μSD μRSD]/r: 0.003ms 2.88%

7 subjects, 58 iterations, 170 revs, 0 rejects
(best [mean mode] worst) = 28.500 [30,863.368 30,654.361] 33.233 (μs)
⅀T: 866,325.900μs μSD/r 352.035μs μRSD/r: 3.812%
suite: 133c83885f65d3c25d9ccbcbf9e0366fdb351f93, date: 2017-08-08, stime: 19:06:50
+--------------------------+----------------------------------+--------+--------+------+-----+-------------+----------+----------+----------+----------+--------+--------+--------------+
| benchmark                | subject                          | groups | params | revs | its | mem_peak    | best     | mean     | mode     | worst    | stdev  | rstdev | diff         |
+--------------------------+----------------------------------+--------+--------+------+-----+-------------+----------+----------+----------+----------+--------+--------+--------------+
| PhpUnitReflectClassBench | test_case                        |        | []     | 10   | 4   | 27,023,328b | 59.59ms  | 60.33ms  | 59.88ms  | 61.78ms  | 0.85ms | 1.41%  | +202,940.41% |
| PhpUnitReflectClassBench | test_case_methods_and_properties |        | []     | 10   | 4   | 53,155,200b | 153.80ms | 155.35ms | 154.35ms | 157.51ms | 1.60ms | 1.03%  | +522,745.75% |
| ReflectPropertyBench     | property                         |        | []     | 30   | 10  | 2,326,032b  | 0.03ms   | 0.03ms   | 0.03ms   | 0.03ms   | 0.00ms | 5.74%  | 0.00%        |
| ReflectPropertyBench     | property_return_type             |        | []     | 30   | 10  | 2,326,040b  | 0.08ms   | 0.08ms   | 0.08ms   | 0.09ms   | 0.00ms | 3.90%  | +184.56%     |
| ReflectMethodBench       | method                           |        | []     | 30   | 10  | 2,327,144b  | 0.03ms   | 0.03ms   | 0.03ms   | 0.04ms   | 0.00ms | 9.04%  | +11.57%      |
| ReflectMethodBench       | method_return_type               |        | []     | 30   | 10  | 2,327,160b  | 0.09ms   | 0.10ms   | 0.09ms   | 0.10ms   | 0.00ms | 2.68%  | +220.92%     |
| ReflectMethodBench       | method_inferred_return_type      |        | []     | 30   | 10  | 2,327,168b  | 0.11ms   | 0.12ms   | 0.11ms   | 0.12ms   | 0.00ms | 2.88%  | +289.81%     |
+--------------------------+----------------------------------+--------+--------+------+-----+-------------+----------+----------+----------+----------+--------+--------+--------------+

```