### PR TITLE
Introduce SCF locator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "phpunit/phpunit": "^6.0@stable",
         "symfony/filesystem": "^3.3",
         "phpbench/phpbench": "^0.13.0",
-        "phpactor/class-to-file": "^1.0@dev"
+        "phpactor/class-to-file": "^1.0@dev",
+        "phpactor/source-code-filesystem": "@dev"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Bridge/Phpactor/SourceCodeFilesystemSourceLocator.php
+++ b/lib/Bridge/Phpactor/SourceCodeFilesystemSourceLocator.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Phpactor\WorseReflection\Bridge\Phpactor;
+
+use Phpactor\WorseReflection\Core\SourceCodeLocator;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\Filesystem\Domain\Filesystem;
+use Phpactor\WorseReflection\Reflector;
+use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
+
+class SourceCodeFilesystemSourceLocator implements SourceCodeLocator
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    /**
+     * @var Reflector
+     */
+    private $reflector;
+
+    public function __construct(Filesystem $filesystem, Reflector $reflector)
+    {
+        $this->filesystem = $filesystem;
+        $this->reflector = $reflector;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function locate(ClassName $className): SourceCode
+    {
+        $files = $this->filesystem->fileList()->phpFiles()->named($className->short());
+
+        foreach ($files as $file) {
+            $sourceCode = SourceCode::fromPath($file);
+            $classes = $this->reflector->reflectClassesIn($sourceCode);
+
+            if ($classes->has((string) $className)) {
+                return $sourceCode;
+            }
+        }
+
+        throw new SourceNotFound(sprintf('Could not locate a file for class "%s"', (string) $className));
+    }
+}
+

--- a/tests/Integration/Bridge/Phpactor/SourceCodeFilesystemSourceLocatorTest.php
+++ b/tests/Integration/Bridge/Phpactor/SourceCodeFilesystemSourceLocatorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Integration\Bridge\Phpactor;
+
+use PHPUnit\Framework\TestCase;
+use Phpactor\Filesystem\Adapter\Simple\SimpleFilesystem;
+use Phpactor\Filesystem\Domain\FilePath;
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Bridge\Phpactor\SourceCodeFilesystemSourceLocator;
+use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
+use Phpactor\WorseReflection\Core\SourceCode;
+use Phpactor\WorseReflection\Core\Exception\SourceNotFound;
+
+class SourceCodeFilesystemSourceLocatorTest extends IntegrationTestCase
+{
+    const NON_EXISTING_CLASS_NAME = 'ThisIsANameThatWillNeverExist';
+
+    public function setUp()
+    {
+        $this->locator = new SourceCodeFilesystemSourceLocator(
+            new SimpleFilesystem(
+                FilePath::fromString(__DIR__ . '/files')
+            ),
+            $this->createReflector('')
+        );
+    }
+
+    public function testLocate()
+    {
+        $source = $this->locator->locate(ClassName::fromString('Acme\\NamespacedClass'));
+        $this->assertPath('Folder1/NamespacedClass.php', $source);
+    }
+
+    public function testLocateNoNamespace()
+    {
+        $source = $this->locator->locate(ClassName::fromString('DB_ManagerNEW1'));
+        $this->assertPath('Folder1/LEGACY/DB_ManagerNEW1.php', $source);
+    }
+
+    public function testNotFound()
+    {
+        $this->expectException(SourceNotFound::class);
+        $source = $this->locator->locate(ClassName::fromString(self::NON_EXISTING_CLASS_NAME));
+        $this->assertEquals(__FILE__, $source->path());
+    }
+
+    private function assertPath(string $expectedPath, SourceCode $source)
+    {
+        $this->assertEquals(__DIR__ . '/files/' . $expectedPath, $source->path());
+    }
+}
+

--- a/tests/Integration/Bridge/Phpactor/files/Folder1/LEGACY/DB_ManagerNEW1.php
+++ b/tests/Integration/Bridge/Phpactor/files/Folder1/LEGACY/DB_ManagerNEW1.php
@@ -1,0 +1,5 @@
+<?php
+
+class DB_ManagerNEW1
+{
+}

--- a/tests/Integration/Bridge/Phpactor/files/Folder1/NamespacedClass.php
+++ b/tests/Integration/Bridge/Phpactor/files/Folder1/NamespacedClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Acme;
+
+class NamespacedClass
+{
+}


### PR DESCRIPTION
This PR introduces a new source locator which can work without composer or GIT.

- [x] Uses the phpactor/source-code-filesystem package to locate classes based on their short names.
- [x] If candidates are found, it checks to see if the class exists, if not we carray on searching.
- [x] Can use basic filesystem adapter (no composer or git).

This should help projects that have classes in non-standard locations. It **will not** help projects where the file name is different from the classes short name.