### PR TITLE
Throw (and catch) exceptions when node cannot be resolved and..

### DIFF
--- a/tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -239,6 +239,23 @@ EOT
                 , [], ['type' => 'string', 'value' => 'test']
                 ];
 
+        yield 'Ignores parameter on anonymous class' => [
+            <<<'EOT'
+<?php
+
+class Foobar {
+
+    public function foobar()
+    {
+        $class = new class { public function __invoke($foo<>bar) {} };
+    }
+}
+
+EOT
+            , [], ['type' => '<unknown>', 'symbol_type' => '<unknown>', 'symbol_name' => '<unknown>']
+        ];
+
+
         yield 'It returns the FQN of a static call' => [
                 <<<'EOT'
 <?php


### PR DESCRIPTION
Added private getClassLikeAncestor method which also takes into account
Anonymous classes.

Anonymous classes are not currently supported and we will add an error
if they are encountered when resolving a node.

Note that this whole class needs to be refactored...

Fixes https://github.com/phpactor/phpactor/issues/505