### PR TITLE
Handle division by zero situation when evaluating expression

### DIFF
--- a/lib/Core/Inference/ExpressionEvaluator.php
+++ b/lib/Core/Inference/ExpressionEvaluator.php
@@ -106,8 +106,17 @@ class ExpressionEvaluator
             case '-':
                 return $leftValue - $rightValue;
             case '%':
+                // do not cause fatal error if right value is zero-ish
+                if (!$rightValue) {
+                    return 0;
+                }
                 return $leftValue % $rightValue;
             case '/':
+                // do not cause fatal error if right value is zero-ish
+                if (!$rightValue) {
+                    return 0;
+                }
+
                 return $leftValue / $rightValue;
             case '.':
                 return $leftValue . $rightValue;
@@ -128,7 +137,7 @@ class ExpressionEvaluator
             case '&':
                 return $leftValue & $rightValue;
             case '|':
-                return $leftValue & $rightValue;
+                return $leftValue | $rightValue;
             case '^':
                 return $leftValue ^ $rightValue;
             case '<<':

--- a/tests/Integration/Core/Inference/ExpressionEvaluatorTest.php
+++ b/tests/Integration/Core/Inference/ExpressionEvaluatorTest.php
@@ -180,7 +180,7 @@ class ExpressionEvaluatorTest extends IntegrationTestCase
 
         yield 'Bitwise or' => [
             'true | true',
-1
+            1
         ];
 
         yield 'Neg' => [
@@ -255,6 +255,16 @@ class ExpressionEvaluatorTest extends IntegrationTestCase
         yield 'missing token' => [
             '(5 > 3) AND (',
             false
+        ];
+
+        yield 'division by zero' => [
+            '5 / 0',
+true
+        ];
+
+        yield 'modulo by zero' => [
+            '5 / 0',
+true
         ];
     }
 }

--- a/tests/Integration/Core/Inference/ExpressionEvaluatorTest.php
+++ b/tests/Integration/Core/Inference/ExpressionEvaluatorTest.php
@@ -257,14 +257,19 @@ class ExpressionEvaluatorTest extends IntegrationTestCase
             false
         ];
 
-        yield 'division by zero' => [
+        yield 'division by zero returns 0 to avoid crash' => [
             '5 / 0',
-true
+            0
         ];
 
-        yield 'modulo by zero' => [
+        yield 'modulo by zero returns 0 to avoid crash' => [
             '5 / 0',
-true
+            0
+        ];
+
+        yield 'division by unresolable constant returns 0' => [
+            '5 / SOME_CONSTANT',
+            0
         ];
     }
 }


### PR DESCRIPTION
If the right value of a modulo or division expression is zero-ish, then
just return 0 as the evaluation rather than crashing.

cc @weirdan