### PR TITLE
Resolves a node to the first resolvable parent

### DIFF
--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -116,6 +116,28 @@ class SymbolContextResolver
         return $context;
     }
 
+    /**
+     * Resolve a node backward until the firsts resolvable node.
+     *
+     * @param Frame $frame
+     * @param Node $node
+     *
+     * @return SymbolContext
+     */
+    public function resolveNodeBackwardsUntilSuccess(Frame $frame, Node $node): SymbolContext
+    {
+        try {
+            return $this->_resolveNode($frame, $node);
+        } catch (CouldNotResolveNode $couldNotResolveNode) {
+            if ($parentNode = $node->getParent()) {
+                return $this->resolveNodeBackwardsUntilSuccess($frame, $parentNode);
+            }
+
+            return SymbolContext::none()
+                ->withIssue($couldNotResolveNode->getMessage());
+        }
+    }
+
     private function __resolveNode(Frame $frame, Node $node): SymbolContext
     {
         $this->logger->debug(sprintf('Resolving: %s', get_class($node)));


### PR DESCRIPTION
The goal is to get the symbol under the cursor if possible but to
fallback to the parent symbol if the one under the cusor is not
resolvable.

So if the cursor is inside a method block but on an empty line, it will
be resolve to the method symbol.
Same if the cursor is between two class members, then the symbol should
be the one of the class.

It's to resolve https://github.com/phpactor/phpactor/issues/777#issue-454088708

EDIT: I mixed up some repositories, will fix that quickly