### PR TITLE
Offset from byte offset

### DIFF
--- a/lib/Core/Offset.php
+++ b/lib/Core/Offset.php
@@ -2,6 +2,8 @@
 
 namespace Phpactor\WorseReflection\Core;
 
+use Phpactor\TextDocument\ByteOffset;
+
 final class Offset
 {
     private $offset;
@@ -20,6 +22,10 @@ final class Offset
 
     public static function fromUnknown($value)
     {
+        if ($value instanceof ByteOffset) {
+            return self::fromInt($value->toInt());
+        }
+
         if ($value instanceof Offset) {
             return $value;
         }

--- a/tests/Unit/Core/OffsetTest.php
+++ b/tests/Unit/Core/OffsetTest.php
@@ -3,11 +3,20 @@
 namespace Phpactor\WorseReflection\Tests\Unit\Core;
 
 use PHPUnit\Framework\TestCase;
+use Phpactor\TextDocument\ByteOffset;
 use Phpactor\WorseReflection\Core\Offset;
 
 class OffsetTest extends TestCase
 {
     const OFFSET = 123;
+
+    public function testFromPhpactorByteOffset()
+    {
+        $byteOffset = ByteOffset::fromInt(self::OFFSET);
+        $offset = Offset::fromUnknown($byteOffset);
+
+        $this->assertSame(self::OFFSET, $offset->toInt());
+    }
 
     public function testFromUnknownReturnsOffsetIfGivenOffset()
     {


### PR DESCRIPTION
Matches the behavior of the `SourceCode` object which can also be created from the standard `TextDocument`