### PR TITLE
Add: parentheses

### DIFF
--- a/lib/Core/Type.php
+++ b/lib/Core/Type.php
@@ -208,7 +208,7 @@ class Type
 
     public function __toString()
     {
-        $className = $this->className ? (string) $this->className : $this->phpType ?: '<unknown>';
+        $className = $this->className ? (string) $this->className : ($this->phpType ?: '<unknown>');
 
         if (null === $this->arrayType) {
             return $className;


### PR DESCRIPTION
I do get a deprecation warning in php7.4, so the goto function stop working for me.
So I added the parentheses.