### PR TITLE
Fix/#1101 properly resolve iterable

### DIFF
--- a/lib/Bridge/TolerantParser/Patch/TolerantQualifiedNameResolver.php
+++ b/lib/Bridge/TolerantParser/Patch/TolerantQualifiedNameResolver.php
@@ -20,6 +20,17 @@ use Microsoft\PhpParser\Node\Expression\ObjectCreationExpression;
 class TolerantQualifiedNameResolver
 {
     /**
+     * Lists of PHP reserved keywords interpreted as QualifiedName by the Tolerant parser
+     * but they should not be resolved to any namespace.
+     *
+     * @todo Remove iterable when Tolerant parser does not considere it as a QualifiedName
+     * @see https://github.com/microsoft/tolerant-php-parser/pull/348
+     *
+     * @var array<string>
+     */
+    private const UNRESOLVABLE_KEYWORD = ['self', 'static', 'parent', 'iterable'];
+
+    /**
      * @see \Microsoft\PhpParser\Node\QualifiedName::getResolvedName
      */
     public static function getResolvedName($node, $namespaceDefinition = null)
@@ -37,7 +48,7 @@ class TolerantQualifiedNameResolver
             return null;
         }
 
-        if (array_search($lowerText = strtolower($node->getText()), ["self", "static", "parent"]) !== false) {
+        if (array_search($lowerText = strtolower($node->getText()), self::UNRESOLVABLE_KEYWORD) !== false) {
             return $lowerText;
         }
 

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionArgument.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionArgument.php
@@ -43,7 +43,7 @@ class ReflectionArgument implements CoreReflectionArgument
         if ($this->node->expression instanceof Variable) {
             $name = $this->node->expression->name->getText($this->node->getFileContents());
 
-            if (substr($name, 0, 1) == '$') {
+            if (is_string($name) && substr($name, 0, 1) == '$') {
                 return substr($name, 1);
             }
 

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -658,7 +658,12 @@ class SymbolContextResolver
             }
         }
 
-        if ('property' === $memberType && $node instanceof ScopedPropertyAccessExpression && substr($memberName, 0, 1) !== '$') {
+        if (
+            'property' === $memberType
+            && $node instanceof ScopedPropertyAccessExpression
+            && is_string($memberName)
+            && substr($memberName, 0, 1) !== '$'
+        ) {
             $memberType = 'constant';
         }
 


### PR DESCRIPTION
Fix https://github.com/phpactor/phpactor/issues/1101

The issue is that the Tolerant parser consider the `iterable` keyword as a `QualifiedName` node.
A PR was submitted to solve this and create a new token of type `IterableKeyword`.

In the meanwhile we need to care of it on our side.
We have a `TolerantQualifiedNameResolver` which kind of "patch" the behavior of `QualifiedName::getResolvedName()` method to be able to resolve traits.
So this PR reuse this service to not resolve `iterable`.