### PR TITLE
fix properties inferred types

### DIFF
--- a/lib/Core/Inference/FrameBuilder/AssertFrameWalker.php
+++ b/lib/Core/Inference/FrameBuilder/AssertFrameWalker.php
@@ -37,10 +37,12 @@ class AssertFrameWalker extends AbstractInstanceOfWalker implements FrameWalker
                 continue;
             }
 
-            $variables = $this->collectVariables($expression);
+            $variables = $this->collectVariables($expression, $frame);
 
             foreach ($variables as $variable) {
-                $frame->locals()->add($variable);
+                $this->getAssignmentsMatchingVariableType($frame, $variable)
+                    ->add($variable)
+                ;
             }
         }
 

--- a/lib/Core/Inference/PropertyAssignments.php
+++ b/lib/Core/Inference/PropertyAssignments.php
@@ -11,6 +11,6 @@ class PropertyAssignments extends Assignments
 
     public static function fromArray(array $assignments): PropertyAssignments
     {
-        return self::fromArray($assignments);
+        return new self($assignments);
     }
 }

--- a/lib/Core/Inference/SymbolContext.php
+++ b/lib/Core/Inference/SymbolContext.php
@@ -50,7 +50,6 @@ final class SymbolContext
         $this->symbol = $symbol;
         $this->containerType = $containerType;
         $this->types = $types;
-        $this->containerType = $containerType;
         $this->scope = $scope;
         $this->name = $name;
     }

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -651,7 +651,7 @@ class SymbolContextResolver
         assert($node instanceof MemberAccessExpression || $node instanceof ScopedPropertyAccessExpression);
 
         $memberName = $node->memberName->getText($node->getFileContents());
-        $memberType = $node->getParent() instanceof CallExpression ? 'method' : 'property';
+        $memberType = $node->getParent() instanceof CallExpression ? Symbol::METHOD : Symbol::PROPERTY;
 
         if ($node->memberName instanceof Node) {
             $memberNameInfo = $this->_resolveNode($frame, $node->memberName);
@@ -661,12 +661,12 @@ class SymbolContextResolver
         }
 
         if (
-            'property' === $memberType
+            Symbol::PROPERTY === $memberType
             && $node instanceof ScopedPropertyAccessExpression
             && is_string($memberName)
             && substr($memberName, 0, 1) !== '$'
         ) {
-            $memberType = 'constant';
+            $memberType = Symbol::CONSTANT;
         }
 
         $information = $this->symbolFactory->context(
@@ -682,7 +682,7 @@ class SymbolContextResolver
         /** @var SymbolContext $info */
         $info = $this->memberTypeResolver->{$memberType . 'Type'}($classType, $information, $memberName);
 
-        if ('property' === $memberType) {
+        if (Symbol::PROPERTY === $memberType) {
             $frameTypes = $this->getFrameTypesForPropertyAtPosition(
                 $frame,
                 (string) $memberName,

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -794,7 +794,7 @@ class SymbolContextResolver
             if (
                 !$containerType
                 || !$containerType->isClass()
-                || $containerType->className() !== $classType->className()
+                || $containerType->className() != $classType->className()
             ) {
                 // Ignore if not a class, could throw LogicException since it shoudl not append
                 // Or if the symbol is for a different class

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -792,7 +792,8 @@ class SymbolContextResolver
             $containerType = $symbolContext->containerType();
 
             if (
-                !$containerType->isClass()
+                !$containerType
+                || !$containerType->isClass()
                 || $containerType->className() !== $classType->className()
             ) {
                 // Ignore if not a class, could throw LogicException since it shoudl not append

--- a/tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/AssertWalkerTest.php
@@ -2,6 +2,7 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalker;
 
+use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Tests\Integration\Core\Inference\FrameWalkerTestCase;
 use Phpactor\WorseReflection\Core\Inference\Frame;
 use Generator;
@@ -36,5 +37,29 @@ EOT
                 $this->assertEquals(0, $frame->locals()->count());
             }
         ];
+
+        yield 'should handle properties' => [
+            <<<'EOT'
+<?php
+
+class Foo
+{
+    private $bar;
+
+    public function bar(): void
+    {
+        assert($this->bar instanceof Bar);
+
+        <>
+    }
+}
+EOT
+        , function (Frame $frame, int $offset) {
+            $this->assertCount(1, $frame->locals());
+            $this->assertEquals(Type::fromString('Foo'), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertCount(1, $frame->properties());
+            $this->assertEquals(Type::fromString('Foo'), $frame->properties()->atIndex(0)->symbolContext()->containerType());
+            $this->assertEquals(Type::fromString('Bar'), $frame->properties()->atIndex(0)->symbolContext()->types()->best());
+        }];
     }
 }

--- a/tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/InstanceOfWalkerTest.php
@@ -264,5 +264,34 @@ EOT
             $this->assertCount(0, $frame->locals());
         }
         ];
+
+        yield 'should handle properties' => [
+            <<<'EOT'
+<?php
+
+class Foo
+{
+    private $bar;
+
+    public function bar(): void
+    {
+        if (!$this->bar instanceof Bar) {
+            continue;
+        }
+
+        <>
+    }
+}
+EOT
+        , function (Frame $frame, int $offset) {
+            $this->assertCount(1, $frame->locals());
+            $this->assertEquals(Type::fromString('Foo'), $frame->locals()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertCount(2, $frame->properties());
+            $this->assertEquals(Type::fromString('Foo'), $frame->properties()->atIndex(0)->symbolContext()->containerType());
+            $this->assertEquals(Type::unknown(), $frame->properties()->atIndex(0)->symbolContext()->types()->best());
+            $this->assertEquals(Type::fromString('Foo'), $frame->properties()->atIndex(1)->symbolContext()->containerType());
+            $this->assertEquals(Type::fromString('Bar'), $frame->properties()->atIndex(1)->symbolContext()->types()->best());
+        }
+        ];
     }
 }


### PR DESCRIPTION
Fix https://github.com/phpactor/phpactor/issues/1126

Currently we only take variables into account.
The problem was that when retrieving the first variable included in the operation we didn't check if it was a property or not.
Whith `$this->property instanceof Class`, the first descendant node of type `Variable` is `$this`. It's a variable but it's also a child of `MemberAccessExpression`.

So I added a check for this case, I also made sure it was not a method call.
Then it was a question of modifying the current code to not use `$frame->locals()` every time but only for variables and then using `$frame->properties()` when dealing with properties.

It fixed the bug, `$this` was not broken anymore but we didn't use the newly inferred type.
So I also updated the `SymbolContextResolver::_infoFromMemberAccess()` method to add the inferred types in addition to those resolved with the reflection.

There is two things I still need to take care of:
- [ ] Writing a test for the `SymbolContextResolver` (I was carried away when fixing it and I didn't stop in time to do it)
- [ ] Figuring out why I have false positive diagnostics

For the test it might take a while, there nothing related to the properties in there, so it might required more work than simply adding a new test case.

For the diagnostics there is for example (in both cases it complains about a non existant property):
https://github.com/phpactor/worse-reflection/blob/682bb4197ad014f10988dc1f1e2335a36902fd34/lib/Core/Inference/SymbolContextResolver.php#L654
But it does not seem to be related to the assert because there is also:
https://github.com/phpactor/worse-reflection/blob/682bb4197ad014f10988dc1f1e2335a36902fd34/lib/Core/Inference/SymbolContextResolver.php#L313
Which is properly typed with PHP so...

P.S.: according to my browser it's not `existant` but `existent`, I would have understand from another French but what's your excuse ? :trollface: 