### PR TITLE
"fake" support for PHP 8.0 Union types

### DIFF
--- a/lib/Bridge/TolerantParser/Reflection/ReflectionMethod.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionMethod.php
@@ -111,14 +111,16 @@ class ReflectionMethod extends AbstractReflectionClassMember implements CoreRefl
     {
         $types = $this->returnTypeResolver->resolve();
 
-        $types = $types->merge($this->memberTypeResolver->resolveOtherTypes(
+        if (!$this->node->otherReturnTypes) {
+            return $types;
+        }
+
+        return $types->merge($this->memberTypeResolver->resolveOtherTypes(
             $this->node,
             $this->node->otherReturnTypes,
-            $this->class()->name(),
+            $this->class()->name(), // note: this call is quite expensive
             $this->node->questionToken ? true : false
         ));
-
-        return $types;
     }
 
     /**

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionMethod.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionMethod.php
@@ -109,7 +109,16 @@ class ReflectionMethod extends AbstractReflectionClassMember implements CoreRefl
 
     public function inferredTypes(): Types
     {
-        return $this->returnTypeResolver->resolve();
+        $types = $this->returnTypeResolver->resolve();
+
+        $types = $types->merge($this->memberTypeResolver->resolveOtherTypes(
+            $this->node,
+            $this->node->otherReturnTypes,
+            $this->class()->name(),
+            $this->node->questionToken ? true : false
+        ));
+
+        return $types;
     }
 
     /**

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionPromotedProperty.php
@@ -80,7 +80,15 @@ class ReflectionPromotedProperty extends AbstractReflectionClassMember implement
 
     public function inferredTypes(): Types
     {
-        return $this->typeResolver->resolve();
+        $types = $this->typeResolver->resolve();
+        $types = $this->memberTypeResolver->resolveOtherTypes(
+            $this->parameter,
+            $this->parameter->otherTypeDeclarations,
+            $this->class()->name(),
+            $this->parameter->questionToken ? true : false
+        );
+
+        return $types;
     }
 
     public function type(): Type

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
@@ -89,6 +89,10 @@ class ReflectionProperty extends AbstractReflectionClassMember implements CoreRe
     {
         $types = $this->typeResolver->resolve();
 
+        if (!$this->propertyDeclaration->otherTypeDeclarations) {
+            return $types;
+        }
+
         $types = $types->merge($this->memberTypeResolver->resolveOtherTypes(
             $this->propertyDeclaration,
             $this->propertyDeclaration->otherTypeDeclarations,

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
@@ -97,7 +97,6 @@ class ReflectionProperty extends AbstractReflectionClassMember implements CoreRe
         ));
 
         return $types;
-        
     }
 
     public function type(): Type

--- a/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
+++ b/lib/Bridge/TolerantParser/Reflection/ReflectionProperty.php
@@ -87,7 +87,17 @@ class ReflectionProperty extends AbstractReflectionClassMember implements CoreRe
 
     public function inferredTypes(): Types
     {
-        return $this->typeResolver->resolve();
+        $types = $this->typeResolver->resolve();
+
+        $types = $types->merge($this->memberTypeResolver->resolveOtherTypes(
+            $this->propertyDeclaration,
+            $this->propertyDeclaration->otherTypeDeclarations,
+            $this->class()->name(),
+            $this->propertyDeclaration->questionToken ? true : false
+        ));
+
+        return $types;
+        
     }
 
     public function type(): Type

--- a/lib/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolver.php
+++ b/lib/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolver.php
@@ -2,11 +2,14 @@
 
 namespace Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\TypeResolver;
 
+use Microsoft\PhpParser\Node\DelimitedList\QualifiedNameList;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Token;
+use Microsoft\PhpParser\TokenKind;
 use Phpactor\WorseReflection\Core\Type;
 use Phpactor\WorseReflection\Core\ClassName;
 use Microsoft\PhpParser\Node;
+use Phpactor\WorseReflection\Core\Types;
 
 class DeclaredMemberTypeResolver
 {
@@ -15,9 +18,24 @@ class DeclaredMemberTypeResolver
         'resource',
     ];
 
+    public function resolveOtherTypes(Node $tolerantNode, ?QualifiedNameList $otherTypes = null, ClassName $className = null, bool $nullable = false): Types
+    {
+        if (!$otherTypes) {
+            return Types::empty();
+        }
+
+        return Types::fromTypes(array_filter(array_map(function ($tolerantType = null) use ($tolerantNode, $className, $nullable) {
+            if ($tolerantType instanceof Token && $tolerantType->kind === TokenKind::BarToken) {
+                return false;
+            }
+            return $this->resolve($tolerantNode, $tolerantType, $className, $nullable);
+        }, $otherTypes->children)));
+    }
+
     public function resolve(Node $tolerantNode, $tolerantType = null, ClassName $className = null, bool $nullable = false): Type
     {
         $type = $this->doResolve($tolerantType, $tolerantNode, $className);
+
         if ($nullable) {
             return $type->asNullable();
         }

--- a/lib/Core/Reflection/ReflectionMember.php
+++ b/lib/Core/Reflection/ReflectionMember.php
@@ -41,6 +41,12 @@ interface ReflectionMember
 
     public function visibility(): Visibility;
 
+    /**
+     * Inferred types.
+     *
+     * Note that this will also return PHP 8.0 union types until the type
+     * system has been refactored to support more complex types.
+     */
     public function inferredTypes(): Types;
 
     public function type(): Type;

--- a/tests/Benchmarks/ReflectPropertyBench.php
+++ b/tests/Benchmarks/ReflectPropertyBench.php
@@ -10,6 +10,7 @@ use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionClass;
  * @Iterations(10)
  * @Revs(30)
  * @OutputTimeUnit("milliseconds", precision=2)
+ * @Assert("variant.mode <= baseline.mode +/- 5%")
  */
 class ReflectPropertyBench extends BaseBenchCase
 {

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionMethodTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionMethodTest.php
@@ -3,6 +3,7 @@
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection;
 
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionMethodCollection;
+use Phpactor\WorseReflection\Core\Types;
 use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
 use Phpactor\WorseReflection\Core\ClassName;
 use Phpactor\WorseReflection\Core\Visibility;
@@ -86,6 +87,21 @@ EOT
             'Foobar',
             function ($methods) {
                 $this->assertEquals(Visibility::public(), $methods->get('method')->visibility());
+            },
+        ];
+        yield 'Union type' => [
+            <<<'EOT'
+<?php
+
+class Foobar { function method1(): string|int {} }
+EOT
+        ,
+            'Foobar',
+            function (ReflectionMethodCollection $methods) {
+                $this->assertEquals(Types::fromTypes([
+                    Type::string(),
+                    Type::int(), 
+                ]), $methods->get('method1')->inferredTypes());
             },
         ];
         yield 'Return type' => [
@@ -176,6 +192,7 @@ EOT
                 );
             },
         ];
+
         yield 'Return type from docblock' => [
             <<<'EOT'
 <?php
@@ -196,6 +213,7 @@ EOT
                 $this->assertEquals(Type::class(ClassName::fromString('Acme\Post')), $methods->get('method1')->inferredTypes()->best());
             },
         ];
+
         yield 'Return type from array docblock' => [
             <<<'EOT'
 <?php

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionMethodTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionMethodTest.php
@@ -100,7 +100,7 @@ EOT
             function (ReflectionMethodCollection $methods) {
                 $this->assertEquals(Types::fromTypes([
                     Type::string(),
-                    Type::int(), 
+                    Type::int(),
                 ]), $methods->get('method1')->inferredTypes());
             },
         ];

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPromotedPropertyTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPromotedPropertyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection;
+
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollection;
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Types;
+use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
+
+class ReflectionPromotedPropertyTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider provideConsturctorPropertyPromotion
+     */
+    public function testReflectProperty(string $source, string $class, \Closure $assertion): void
+    {
+        $class = $this->createReflector($source)->reflectClassLike(ClassName::fromString($class));
+        $assertion($class->properties());
+    }
+
+    public function provideConsturctorPropertyPromotion(): \Generator
+    {
+        yield 'Typed properties' => [
+                <<<'EOT'
+<?php
+
+namespace Test;
+
+class Barfoo
+{
+    public function __construct(
+        private string $foobar
+        private int $barfoo,
+        private string|int $baz
+    ) {}
+}
+EOT
+                ,
+                'Test\Barfoo',
+                function (ReflectionPropertyCollection $properties) {
+                    $this->assertTrue($properties->get('foobar')->isPromoted());
+                    $this->assertEquals(
+                        Type::string(),
+                        $properties->get('foobar')->type()
+                    );
+                    $this->assertEquals(
+                        Type::int(),
+                        $properties->get('barfoo')->type()
+                    );
+                    $this->assertEquals(
+                        Types::fromTypes([
+                            Type::string(),
+                            Type::int(),
+                        ]),
+                        $properties->get('baz')->inferredTypes()
+                    );
+                },
+            ];
+
+        yield 'Nullable' => [
+                '<?php class Barfoo { public function __construct(private ?string $foobar){}}',
+                'Barfoo',
+                function (ReflectionPropertyCollection $properties) {
+                    $this->assertEquals(
+                        Type::string()->asNullable(),
+                        $properties->get('foobar')->type()
+                    );
+                },
+            ];
+
+        yield 'No types' => [
+                '<?php class Barfoo { public function __construct(private $foobar){}}',
+                'Barfoo',
+                function (ReflectionPropertyCollection $properties) {
+                    $this->assertEquals(
+                        Type::undefined(),
+                        $properties->get('foobar')->type()
+                    );
+                },
+            ];
+    }
+}

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
@@ -4,6 +4,7 @@ namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Refle
 
 use Generator;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollection;
+use Phpactor\WorseReflection\Core\Types;
 use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
 use Phpactor\WorseReflection\Core\ClassName;
 use Phpactor\WorseReflection\Core\Visibility;
@@ -13,6 +14,7 @@ use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
 class ReflectionPropertyTest extends IntegrationTestCase
 {
     /**
+     * @dataProvider provideReflectionPropertyTypes
      * @dataProvider provideReflectionProperty
      * @dataProvider provideConsturctorPropertyPromotion
      */
@@ -20,6 +22,21 @@ class ReflectionPropertyTest extends IntegrationTestCase
     {
         $class = $this->createReflector($source)->reflectClassLike(ClassName::fromString($class));
         $assertion($class->properties());
+    }
+
+    public function provideReflectionPropertyTypes(): \Generator
+    {
+        yield 'It reflects a property with union type' => [
+            '<?php class Foobar { private int|string $property;}',
+                'Foobar',
+                function ($properties) {
+                    $this->assertEquals('property', $properties->get('property')->name());
+                    $this->assertEquals(Types::fromTypes([
+                        Type::int(),
+                        Type::string(),
+                    ]), $properties->get('property')->inferredTypes());
+                },
+        ];
     }
 
     public function provideReflectionProperty()

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
@@ -16,7 +16,6 @@ class ReflectionPropertyTest extends IntegrationTestCase
     /**
      * @dataProvider provideReflectionPropertyTypes
      * @dataProvider provideReflectionProperty
-     * @dataProvider provideConsturctorPropertyPromotion
      */
     public function testReflectProperty(string $source, string $class, \Closure $assertion): void
     {
@@ -369,58 +368,4 @@ EOT
             ];
     }
 
-
-    public function provideConsturctorPropertyPromotion(): Generator
-    {
-        yield 'Typed properties' => [
-                <<<'EOT'
-<?php
-
-namespace Test;
-
-class Barfoo
-{
-    public function __construct(
-        private string $foobar
-        private int $barfoo
-    ) {}
-}
-EOT
-                ,
-                'Test\Barfoo',
-                function (ReflectionPropertyCollection $properties) {
-                    $this->assertTrue($properties->get('foobar')->isPromoted());
-                    $this->assertEquals(
-                        Type::string(),
-                        $properties->get('foobar')->type()
-                    );
-                    $this->assertEquals(
-                        Type::int(),
-                        $properties->get('barfoo')->type()
-                    );
-                },
-            ];
-
-        yield 'Nullable' => [
-                '<?php class Barfoo { public function __construct(private ?string $foobar){}}',
-                'Barfoo',
-                function (ReflectionPropertyCollection $properties) {
-                    $this->assertEquals(
-                        Type::string()->asNullable(),
-                        $properties->get('foobar')->type()
-                    );
-                },
-            ];
-
-        yield 'No types' => [
-                '<?php class Barfoo { public function __construct(private $foobar){}}',
-                'Barfoo',
-                function (ReflectionPropertyCollection $properties) {
-                    $this->assertEquals(
-                        Type::undefined(),
-                        $properties->get('foobar')->type()
-                    );
-                },
-            ];
-    }
 }

--- a/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/ReflectionPropertyTest.php
@@ -2,7 +2,6 @@
 
 namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection;
 
-use Generator;
 use Phpactor\WorseReflection\Core\Reflection\Collection\ReflectionPropertyCollection;
 use Phpactor\WorseReflection\Core\Types;
 use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
@@ -367,5 +366,4 @@ EOT
                 },
             ];
     }
-
 }

--- a/tests/Integration/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolverTest.php
+++ b/tests/Integration/Bridge/TolerantParser/Reflection/TypeResolver/DeclaredMemberTypeResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Phpactor\WorseReflection\Tests\Integration\Bridge\TolerantParser\Reflection\TypeResolver;
+
+use Phpactor\WorseReflection\Core\ClassName;
+use Phpactor\WorseReflection\Core\Type;
+use Phpactor\WorseReflection\Core\Types;
+use Phpactor\WorseReflection\Core\Reflection\ReflectionProperty;
+use Phpactor\WorseReflection\Tests\Integration\IntegrationTestCase;
+
+class DeclaredMemberTypeResolverTest extends IntegrationTestCase
+{
+    /**
+     * @dataProvider provideResolveTypes
+     */
+    public function testResolveTypes(string $source, string $class, \Closure $assertion)
+    {
+        $class = $this->createReflector($source)->reflectClass(ClassName::fromString($class));
+        $assertion($class->properties()->get('p'));
+    }
+
+    public function provideResolveTypes(): \Generator
+    {
+        yield 'union type' => [
+            '<?php class C { private int|string $p; }',
+                'C',
+                function (ReflectionProperty $property) {
+                    $this->assertEquals(Types::fromTypes([
+                        Type::int(),
+                        Type::string(),
+                    ]), $property->inferredTypes());
+                },
+        ];
+
+        yield 'union type with FQN' => [
+            '<?php class C { private int|Foobar|Baz $p; }',
+                'C',
+                function (ReflectionProperty $property) {
+                    $this->assertEquals(Types::fromTypes([
+                        Type::int(),
+                        Type::class('Foobar'),
+                        Type::class('Baz'),
+                    ]), $property->inferredTypes());
+                },
+        ];
+    }
+}


### PR DESCRIPTION
Supporting union types properly would mean changing the public API, as currently we have `$member->type(): Type`, so for now the uninon types are appended to the `inferredTypes` which should be enough for completion - although not for code generation etc.

It makes it clearer however how limited the type system is implemented in WR - going forward we need to rethink in order to be able to support not only union types, but generics also, so that we could return typed _types_! (e.g. `$member->type(); // UnionType(StringType, IntType>` or `GenericType(MyCollection, [ 'T' => IntType])`