### PR TITLE
Fix integration with completion, resolve static variable access on instances, docblock on interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /.phpbench
 .phpunit.result.cache
 /.vscode
+smoke_test.log

--- a/lib/Bridge/Phpactor/Docblock.php
+++ b/lib/Bridge/Phpactor/Docblock.php
@@ -5,6 +5,7 @@ namespace Phpactor\WorseReflection\Bridge\Phpactor;
 use Phpactor\Docblock\DocblockType;
 use Phpactor\Docblock\DocblockTypes;
 use Phpactor\Docblock\Tag\MethodTag;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Reflection\ReflectionInterface;
 use Phpactor\WorseReflection\Core\Deprecation;
 use Phpactor\WorseReflection\Core\DocBlock\DocBlock as CoreDocblock;
 use Phpactor\Docblock\Docblock as PhpactorDocblock;
@@ -156,6 +157,9 @@ class Docblock implements CoreDocblock
         $properties = [];
         foreach ($this->docblock->tags()->byName('property') as $propertyTag) {
             if (!$propertyTag->propertyName()) {
+                continue;
+            }
+            if ($declaringClass instanceof ReflectionInterface) {
                 continue;
             }
             $properties[$propertyTag->propertyName()] = $this->propertyFactory->create($this, $declaringClass, $propertyTag);

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -175,8 +175,8 @@ class SymbolContextResolver
             $value = $this->expressionEvaluator->evaluate($node);
             return $this->symbolFactory->context(
                 $node->getText(),
-                $node->getEndPosition(),
                 $node->getStart(),
+                $node->getEndPosition(),
                 [
                     'symbol_type' => Symbol::CLASS_,
                     'type' => Type::fromValue($value),
@@ -188,8 +188,8 @@ class SymbolContextResolver
         if ($node instanceof ClassDeclaration || $node instanceof TraitDeclaration || $node instanceof InterfaceDeclaration) {
             return $this->symbolFactory->context(
                 $node->name->getText($node->getFileContents()),
-                $node->name->getEndPosition(),
                 $node->name->getStartPosition(),
+                $node->name->getEndPosition(),
                 [
                     'name' => Name::fromString($node->getNamespacedName()),
                     'symbol_type' => Symbol::CLASS_,
@@ -201,8 +201,8 @@ class SymbolContextResolver
         if ($node instanceof FunctionDeclaration) {
             return $this->symbolFactory->context(
                 $node->name->getText($node->getFileContents()),
-                $node->name->getEndPosition(),
                 $node->name->getStartPosition(),
+                $node->name->getEndPosition(),
                 [
                     'name' => Name::fromString($node->getNamespacedName()),
                     'symbol_type' => Symbol::FUNCTION,

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -605,11 +605,7 @@ class SymbolContextResolver
         if ($node->scopeResolutionQualifier instanceof ParserVariable) {
             /** @var SymbolContext $context */
             $context = $this->resolveVariable($frame, $node->scopeResolutionQualifier);
-            if (
-                $context->types() !== null &&
-                $context->types()->count() > 0 &&
-                $context->type()->className() !== null
-            ) {
+            if ($context->type()->className() !== null) {
                 $name = $context->type()->className()->__toString();
             }
         }

--- a/tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -56,7 +56,6 @@ class SymbolContextResolverTest extends IntegrationTestCase
             PropertyAssignments::fromArray($properties),
             $source,
         );
-
         $this->assertExpectedInformation($expectedInformation, $symbolInfo);
     }
 
@@ -688,6 +687,29 @@ EOT
                         'container_type' => 'Foobar',
                     ],
                 ];
+
+        yield 'Static property access (instance)' => [
+            <<<'EOT'
+<?php
+
+class Foobar
+{
+/** @var string */
+public static $myProperty = 'hello';
+}
+
+$foobar = new Foobar();
+$foobar::$my<>Property = 5;
+EOT
+            , [
+                'foobar' => Type::fromString("Foobar")
+            ], [
+                'type' => 'string',
+                'symbol_type' => Symbol::PROPERTY,
+                'symbol_name' => 'myProperty',
+                'container_type' => 'Foobar',
+            ],
+        ];
 
         yield 'Member access with variable' => [
                 <<<'EOT'


### PR DESCRIPTION
1. For variables: resolve the parent `ScopedPropertyAccessExpression` only if the variable is the memberName.
2. When resolving `ScopedPropertyAccessExpression` see if `scopeResolutionQualifier` is a `Variable` and then resolve it to get the type, rather than taking the text and treating it as a type.
3. Ignore smoke_test.log
4. Don't search for properties in docblocks on interfaces