### PR TITLE
List foreach

### DIFF
--- a/lib/Core/Inference/Assignments.php
+++ b/lib/Core/Inference/Assignments.php
@@ -2,13 +2,22 @@
 
 namespace Phpactor\WorseReflection\Core\Inference;
 
-abstract class Assignments implements \Countable, \IteratorAggregate
+use Countable;
+use IteratorAggregate;
+
+/**
+ * @implements IteratorAggregate<int,Variable>
+ */
+abstract class Assignments implements Countable, IteratorAggregate
 {
     /**
-     * @var array
+     * @var Variable[]
      */
     private $variables = [];
 
+    /**
+     * @param Variable[] $variables
+     */
     protected function __construct(array $variables)
     {
         foreach ($variables as $variable) {
@@ -16,11 +25,14 @@ abstract class Assignments implements \Countable, \IteratorAggregate
         }
     }
 
-    public function add(Variable $variable)
+    public function add(Variable $variable): void
     {
         $this->variables[] = $variable;
     }
 
+    /**
+     * @return self
+     */
     public function byName(string $name): Assignments
     {
         return new static(array_filter($this->variables, function (Variable $variable) use ($name) {
@@ -114,5 +126,22 @@ abstract class Assignments implements \Countable, \IteratorAggregate
         }
 
         return $this;
+    }
+
+    public function replace(Variable $existing, Variable $replacement): void
+    {
+        foreach ($this->variables as $index => $variable) {
+            if ($variable !== $existing) {
+                continue;
+            }
+            $this->variables[$index] = $replacement;
+        }
+    }
+
+    public function equalTo(int $offset): Assignments
+    {
+        return new static(array_filter($this->variables, function (Variable $variable) use ($offset) {
+            return $variable->offset()->toInt() === $offset;
+        }));
     }
 }

--- a/lib/Core/Inference/FrameBuilder/AssignmentWalker.php
+++ b/lib/Core/Inference/FrameBuilder/AssignmentWalker.php
@@ -48,21 +48,24 @@ class AssignmentWalker extends AbstractWalker
         }
 
         if ($node->leftOperand instanceof Variable) {
-            return $this->walkParserVariable($frame, $node->leftOperand, $rightContext);
+            $this->walkParserVariable($frame, $node->leftOperand, $rightContext);
+            return $frame;
         }
 
         if ($node->leftOperand instanceof ListIntrinsicExpression) {
-            return $this->walkList($frame, $node->leftOperand, $rightContext);
+            $this->walkList($frame, $node->leftOperand, $rightContext);
+            return $frame;
         }
 
         if ($node->leftOperand instanceof MemberAccessExpression) {
-            return $this->walkMemberAccessExpression($builder, $frame, $node->leftOperand, $rightContext);
+            $this->walkMemberAccessExpression($builder, $frame, $node->leftOperand, $rightContext);
+            return $frame;
         }
 
         if ($node->leftOperand instanceof SubscriptExpression) {
-            return $this->walkSubscriptExpression($builder, $frame, $node->leftOperand, $rightContext);
+            $this->walkSubscriptExpression($builder, $frame, $node->leftOperand, $rightContext);
+            return $frame;
         }
-
 
         $this->logger->warning(sprintf(
             'Do not know how to assign to left operand "%s"',
@@ -72,8 +75,9 @@ class AssignmentWalker extends AbstractWalker
         return $frame;
     }
 
-    private function walkParserVariable(Frame $frame, Variable $leftOperand, SymbolContext $rightContext)
+    private function walkParserVariable(Frame $frame, Variable $leftOperand, SymbolContext $rightContext): void
     {
+        /** @phpstan-ignore-next-line */
         $name = $leftOperand->name->getText($leftOperand->getFileContents());
         $context = $this->symbolFactory()->context(
             $name,
@@ -87,8 +91,6 @@ class AssignmentWalker extends AbstractWalker
         );
 
         $frame->locals()->add(WorseVariable::fromSymbolContext($context));
-
-        return $frame;
     }
 
     private function walkMemberAccessExpression(

--- a/lib/Core/Inference/FrameBuilder/ForeachWalker.php
+++ b/lib/Core/Inference/FrameBuilder/ForeachWalker.php
@@ -126,14 +126,22 @@ class ForeachWalker extends AbstractWalker
             return;
         }
 
+        $values = (array)$collection->value();
+        $index = 0;
         foreach ($elements->children as $child) {
             if (!$child instanceof ArrayElement) {
                 continue;
             }
 
             $context = $builder->resolveNode($frame, $child->elementValue);
+            $context = $context->withType($collection->type()->arrayType());
+
+            if (isset($values[$index])) {
+                $context = $context->withValue($values[$index]);
+            }
 
             $frame->locals()->add(WorseVariable::fromSymbolContext($context));
+            $index++;
         }
     }
 }

--- a/lib/Core/Inference/FrameBuilder/ForeachWalker.php
+++ b/lib/Core/Inference/FrameBuilder/ForeachWalker.php
@@ -50,7 +50,6 @@ class ForeachWalker extends AbstractWalker
         if ($expression instanceof ArrayCreationExpression) {
             $this->valueFromArrayCreation($builder, $expression, $node, $collection, $frame);
         }
-        
     }
 
     private function processKey(ForeachStatement $node, Frame $frame, SymbolContext $collection): void
@@ -119,10 +118,9 @@ class ForeachWalker extends AbstractWalker
         ForeachStatement $node,
         SymbolContext $collection,
         Frame $frame
-    ): void
-    {
+    ): void {
         $elements = $expression->arrayElements;
-        if(!$elements instanceof ArrayElementList) {
+        if (!$elements instanceof ArrayElementList) {
             return;
         }
 

--- a/lib/Core/Type.php
+++ b/lib/Core/Type.php
@@ -191,6 +191,11 @@ class Type
         return $instance;
     }
 
+    public function phpType(): string
+    {
+        return $this->phpType;
+    }
+
     public static function undefined(): Type
     {
         return new self(null);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -961,22 +961,12 @@ parameters:
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
 
 		-
-			message: "#^Argument of an invalid type Microsoft\\\\PhpParser\\\\Node\\\\DelimitedList\\\\ListExpressionList supplied for foreach, only iterables are supported\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between null and Microsoft\\\\PhpParser\\\\Node\\\\Expression\\\\Variable will always evaluate to false\\.$#"
+			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\AssignmentWalker\\:\\:hasMissingTokens\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
 
 		-
 			message: "#^Method Microsoft\\\\PhpParser\\\\Node\\:\\:getText\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\AssignmentWalker\\:\\:hasMissingTokens\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -961,11 +961,6 @@ parameters:
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\AssignmentWalker\\:\\:hasMissingTokens\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
-
-		-
 			message: "#^Method Microsoft\\\\PhpParser\\\\Node\\:\\:getText\\(\\) invoked with 1 parameter, 0 required\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -791,68 +791,8 @@ parameters:
 			path: lib/Core/DocBlock/DocBlockVars.php
 
 		-
-			message: "#^Class Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Property Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:\\$variables type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:__construct\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:add\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:byName\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 5
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:lessThanOrEqualTo\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:lessThan\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:greaterThan\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:greaterThanOrEqualTo\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:getIterator\\(\\) return type has no value type specified in iterable type Traversable\\<mixed, mixed\\>\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:merge\\(\\) has parameter \\$variables with no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Assignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\:\\:merge\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
-			count: 1
+			count: 6
 			path: lib/Core/Inference/Assignments.php
 
 		-
@@ -941,37 +881,12 @@ parameters:
 			path: lib/Core/Inference/ExpressionEvaluator.php
 
 		-
-			message: "#^Property Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:\\$properties type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\PropertyAssignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
-			message: "#^Property Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:\\$locals type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
 			message: "#^Property Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:\\$problems type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Problems\\.$#"
 			count: 1
 			path: lib/Core/Inference/Frame.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:__construct\\(\\) has parameter \\$locals with no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:__construct\\(\\) has parameter \\$problems with no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Problems\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:__construct\\(\\) has parameter \\$properties with no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\PropertyAssignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:properties\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Assignments\\.$#"
 			count: 1
 			path: lib/Core/Inference/Frame.php
 
@@ -1006,11 +921,6 @@ parameters:
 			path: lib/Core/Inference/Frame.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\Frame\\:\\:withLocals\\(\\) has parameter \\$locals with no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\.$#"
-			count: 1
-			path: lib/Core/Inference/Frame.php
-
-		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\:\\:create\\(\\) has parameter \\$walkers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder.php
@@ -1041,16 +951,6 @@ parameters:
 			path: lib/Core/Inference/FrameBuilder/AbstractInstanceOfWalker.php
 
 		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\AssignmentWalker\\:\\:walkParserVariable\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
-
-		-
-			message: "#^Method Microsoft\\\\PhpParser\\\\Node\\:\\:getText\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 2
-			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
-
-		-
 			message: "#^Parameter \\#1 \\$symbolName of method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolFactory\\:\\:context\\(\\) expects string, bool\\|string\\|null given\\.$#"
 			count: 3
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
@@ -1071,6 +971,11 @@ parameters:
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
 
 		-
+			message: "#^Method Microsoft\\\\PhpParser\\\\Node\\:\\:getText\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 1
+			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
+
+		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\AssignmentWalker\\:\\:hasMissingTokens\\(\\) has no return typehint specified\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder/AssignmentWalker.php
@@ -1084,26 +989,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$symbolName of method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolFactory\\:\\:context\\(\\) expects string, bool\\|string\\|null given\\.$#"
 			count: 1
 			path: lib/Core/Inference/FrameBuilder/CatchWalker.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\ForeachWalker\\:\\:processValue\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/ForeachWalker.php
-
-		-
-			message: "#^Method Microsoft\\\\PhpParser\\\\Node\\:\\:getText\\(\\) invoked with 1 parameter, 0 required\\.$#"
-			count: 2
-			path: lib/Core/Inference/FrameBuilder/ForeachWalker.php
-
-		-
-			message: "#^Parameter \\#1 \\$symbolName of method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolFactory\\:\\:context\\(\\) expects string, bool\\|string\\|null given\\.$#"
-			count: 2
-			path: lib/Core/Inference/FrameBuilder/ForeachWalker.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\ForeachWalker\\:\\:processKey\\(\\) has no return typehint specified\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/ForeachWalker.php
 
 		-
 			message: "#^Parameter \\#3 \\$node of method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FrameBuilder\\\\FunctionLikeWalker\\:\\:walkFunctionLike\\(\\) expects Microsoft\\\\PhpParser\\\\Node\\\\Expression\\\\AnonymousFunctionCreationExpression\\|Microsoft\\\\PhpParser\\\\Node\\\\Statement\\\\FunctionDeclaration, Microsoft\\\\PhpParser\\\\FunctionLike&Microsoft\\\\PhpParser\\\\Node given\\.$#"
@@ -1181,11 +1066,6 @@ parameters:
 			path: lib/Core/Inference/FrameBuilder/VariableWalker.php
 
 		-
-			message: "#^Parameter \\#1 \\$symbolName of method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\SymbolFactory\\:\\:context\\(\\) expects string, bool\\|string\\|null given\\.$#"
-			count: 1
-			path: lib/Core/Inference/FrameBuilder/VariableWalker.php
-
-		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\FullyQualifiedNameResolver\\:\\:resolve\\(\\) has parameter \\$type with no typehint specified\\.$#"
 			count: 1
 			path: lib/Core/Inference/FullyQualifiedNameResolver.php
@@ -1232,11 +1112,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\:\\:fromArray\\(\\) has parameter \\$assignments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Inference/LocalAssignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\:\\:fromArray\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\LocalAssignments\\.$#"
 			count: 1
 			path: lib/Core/Inference/LocalAssignments.php
 
@@ -1327,11 +1202,6 @@ parameters:
 
 		-
 			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\PropertyAssignments\\:\\:fromArray\\(\\) has parameter \\$assignments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: lib/Core/Inference/PropertyAssignments.php
-
-		-
-			message: "#^Method Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\PropertyAssignments\\:\\:fromArray\\(\\) return type has no value type specified in iterable type Phpactor\\\\WorseReflection\\\\Core\\\\Inference\\\\PropertyAssignments\\.$#"
 			count: 1
 			path: lib/Core/Inference/PropertyAssignments.php
 

--- a/tests/Benchmarks/SelfReflectClassBench.php
+++ b/tests/Benchmarks/SelfReflectClassBench.php
@@ -10,6 +10,7 @@ use Phpactor\WorseReflection\Core\ClassName;
  * @Warmup(1)
  * @OutputTimeUnit("milliseconds", precision=2)
  * @Assert("variant.mode <= baseline.mode +/- 10%")
+ * @Assert("variant.mem_peak <= baseline.mem_final")
  */
 class SelfReflectClassBench extends BaseBenchCase
 {

--- a/tests/Benchmarks/SelfReflectClassBench.php
+++ b/tests/Benchmarks/SelfReflectClassBench.php
@@ -10,7 +10,7 @@ use Phpactor\WorseReflection\Core\ClassName;
  * @Warmup(1)
  * @OutputTimeUnit("milliseconds", precision=2)
  * @Assert("variant.mode <= baseline.mode +/- 10%")
- * @Assert("variant.mem_peak <= baseline.mem_final")
+ * @Assert("variant.mem_peak <= baseline.mem_final +/- 10%")
  */
 class SelfReflectClassBench extends BaseBenchCase
 {

--- a/tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/AssignmentWalkerTest.php
@@ -192,6 +192,20 @@ EOT
             }
         ];
 
+        yield 'New list assignment' => [
+            <<<'EOT'
+<?php
+[$foo, $bar] = [ 'foo', 'bar' ];
+<>
+EOT
+        ,
+            function (Frame $frame) {
+                $this->assertCount(2, $frame->locals());
+                $this->assertEquals('foo', $frame->locals()->atIndex(0)->symbolContext()->value());
+                $this->assertEquals('bar', $frame->locals()->atIndex(1)->symbolContext()->value());
+            }
+        ];
+
         yield 'From return type with docblock' => [
             <<<'EOT'
 <?php

--- a/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -115,5 +115,20 @@ EOT
             $symbolInformation = $vars->atIndex(1)->symbolContext();
             $this->assertEquals('Foobar', (string) $symbolInformation->type());
         }];
+
+        yield 'List assignment in foreach' => [
+            <<<'EOT'
+<?php
+foreach (['foo', 'bar'] as [ $foo, $bar ]) {
+    <>
+}
+EOT
+        ,
+            function (Frame $frame) {
+                $this->assertCount(2, $frame->locals());
+                $this->assertEquals('foo', $frame->locals()->atIndex(0)->symbolContext()->value());
+                $this->assertEquals('bar', $frame->locals()->atIndex(1)->symbolContext()->value());
+            }
+        ];
     }
 }

--- a/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -126,8 +126,8 @@ EOT
         ,
             function (Frame $frame) {
                 $this->assertCount(2, $frame->locals());
-                $this->assertEquals('foo', $frame->locals()->atIndex(0)->symbolContext()->value());
-                $this->assertEquals('bar', $frame->locals()->atIndex(1)->symbolContext()->value());
+                $this->assertEquals('foo', $frame->locals()->atIndex(0)->name());
+                $this->assertEquals('bar', $frame->locals()->atIndex(1)->name());
             }
         ];
     }

--- a/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
+++ b/tests/Integration/Core/Inference/FrameWalker/ForeachWalkerTest.php
@@ -24,7 +24,7 @@ foreach ($items as $item) {
 EOT
         ,
             function (Frame $frame) {
-                $this->assertCount(3, $frame->locals());
+                $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
                 $this->assertEquals('int', (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best());
             }
@@ -42,7 +42,7 @@ foreach ($items as $key => $item) {
 EOT
         ,
             function (Frame $frame) {
-                $this->assertCount(4, $frame->locals());
+                $this->assertCount(3, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('key'));
                 $this->assertEquals(Type::unknown(), $frame->locals()->byName('key')->first()->symbolContext()->types()->best());
                 $this->assertEquals(Symbol::VARIABLE, $frame->locals()->byName('key')->first()->symbolContext()->symbol()->symbolType());
@@ -65,7 +65,7 @@ foreach ($items as $item) {
 EOT
         ,
             function (Frame $frame) {
-                $this->assertCount(3, $frame->locals());
+                $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
                 $this->assertEquals('Foobar\\Barfoo', (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best());
             }
@@ -86,9 +86,12 @@ foreach ($items as $item) {
 EOT
         ,
             function (Frame $frame) {
-                $this->assertCount(3, $frame->locals());
+                $this->assertCount(2, $frame->locals());
                 $this->assertCount(1, $frame->locals()->byName('item'));
-                $this->assertEquals('Foobar\\Collection', (string) $frame->locals()->byName('items')->first()->symbolContext()->types()->best());
+                $this->assertEquals(
+                    'Foobar\\Collection<Foobar\Item>',
+                    (string) $frame->locals()->byName('items')->first()->symbolContext()->types()->best()
+                );
                 $this->assertEquals('Foobar\\Item', (string) $frame->locals()->byName('item')->first()->symbolContext()->types()->best());
             }
         ];
@@ -128,6 +131,39 @@ EOT
                 $this->assertCount(2, $frame->locals());
                 $this->assertEquals('foo', $frame->locals()->atIndex(0)->name());
                 $this->assertEquals('bar', $frame->locals()->atIndex(1)->name());
+                $this->assertEquals(
+                    'foo',
+                    $frame->locals()->byName('foo')->first()->symbolContext()->value()
+                );
+                $this->assertEquals(
+                    'bar',
+                    $frame->locals()->byName('bar')->first()->symbolContext()->value()
+                );
+            }
+        ];
+
+        yield 'Typed array' => [
+            <<<'EOT'
+<?php
+/** @var string[] $vars */
+$vars = ['one', 'two'];
+
+foreach ($vars as [ $foo, $bar ]) {
+    <>
+}
+EOT
+        ,
+            function (Frame $frame) {
+                $this->assertEquals(
+                    Type::string(),
+                    $frame->locals()->byName('foo')->atIndex(0)->symbolContext()->type(),
+                    'Type'
+                );
+                $this->assertEquals(
+                    'one',
+                    $frame->locals()->byName('foo')->first()->symbolContext()->value(),
+                    'Value'
+                );
             }
         ];
     }


### PR DESCRIPTION
- Support for `foreach (['foo', 'bar'] as [$foo, $bar])` (type and value included)
- Support for assigning to array creation expressions `[$foo, $bar] = ['foo', 'bar'];`