### PR TITLE
Remove default values

### DIFF
--- a/lib/Core/ServiceLocator.php
+++ b/lib/Core/ServiceLocator.php
@@ -64,8 +64,8 @@ class ServiceLocator
         SourceCodeLocator $sourceLocator,
         LoggerInterface $logger,
         SourceCodeReflectorFactory $reflectorFactory,
-        array $frameWalkers = [],
-        array $methodProviders = [],
+        array $frameWalkers,
+        array $methodProviders,
         Cache $cache,
         bool $enableContextualLocation = false
     ) {


### PR DESCRIPTION
These parameters are followed by mandatory parameters, it makes no sense
to have a default value for those.
Also, this causes a deprecation starting with PHP 8, and phpactor does
not like having those in the output.

Fixes #102