### PR TITLE
SymbolContextResolver: handle non decimal integers

### DIFF
--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -458,18 +458,9 @@ class SymbolContextResolver
     private function resolveNumericLiteral(NumericLiteral $node): SymbolContext
     {
         // Strip PHP 7.4 underscorse separator before comparison
-        $value = str_replace('_', '', $node->getText());
-        if (1 === preg_match('/^[1-9][0-9]*$/', $value)) {
-            $value = (int) $value;
-        } elseif (1 === preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
-            $value = hexdec(substr($value, 2));
-        } elseif (1 === preg_match('/^0[0-7]+$/', $value)) {
-            $value = octdec(substr($value, 1));
-        } elseif (1 === preg_match('/^0[bB][01]+$/', $value)) {
-            $value = bindec(substr($value, 2));
-        } else {
-            $value = (float) $value;
-        }
+        $value = $this->convertNumericStringToInternalType(
+            str_replace('_', '', $node->getText())
+        );
 
         return $this->symbolFactory->context(
             $node->getText(),
@@ -482,6 +473,27 @@ class SymbolContextResolver
                 'container_type' => $this->classTypeFromNode($node)
             ]
         );
+    }
+
+    /**
+     * @return int|float
+     */
+    private function convertNumericStringToInternalType(string $value)
+    {
+        if (1 === preg_match('/^[1-9][0-9]*$/', $value)) {
+            return (int) $value;
+        }
+        if (1 === preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
+            return hexdec(substr($value, 2));
+        }
+        if (1 === preg_match('/^0[0-7]+$/', $value)) {
+            return octdec(substr($value, 1));
+        }
+        if (1 === preg_match('/^0[bB][01]+$/', $value)) {
+            return bindec(substr($value, 2));
+        }
+
+        return (float) $value;
     }
 
     private function resolveReservedWord(Node $node): SymbolContext

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -457,8 +457,7 @@ class SymbolContextResolver
 
     private function resolveNumericLiteral(NumericLiteral $node): SymbolContext
     {
-        // note hack to cast to either an int or a float
-        $value = $node->getText() + 0;
+        $value = eval(sprintf('return %s;', $node->getText()));
 
         return $this->symbolFactory->context(
             $node->getText(),

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -457,7 +457,18 @@ class SymbolContextResolver
 
     private function resolveNumericLiteral(NumericLiteral $node): SymbolContext
     {
-        $value = eval(sprintf('return %s;', $node->getText()));
+        $value = $node->getText();
+        if (0 === strpos($value, '0b')) {
+            $value = bindec(substr($value, 2));
+        } elseif (0 === strpos($value, '0x')) {
+            $value = hexdec(substr($value, 2));
+        } elseif (1 === preg_match('/^0\\d+$/', $value)) {
+            $value = octdec(substr($value, 1));
+        } elseif (1 === preg_match('/^\\d+\\.\\d*$/', $value)) {
+            $value = (float) $value;
+        } else {
+            $value = (int) $value;
+        }
 
         return $this->symbolFactory->context(
             $node->getText(),

--- a/lib/Core/Inference/SymbolContextResolver.php
+++ b/lib/Core/Inference/SymbolContextResolver.php
@@ -457,17 +457,18 @@ class SymbolContextResolver
 
     private function resolveNumericLiteral(NumericLiteral $node): SymbolContext
     {
-        $value = $node->getText();
-        if (0 === strpos($value, '0b')) {
-            $value = bindec(substr($value, 2));
-        } elseif (0 === strpos($value, '0x')) {
-            $value = hexdec(substr($value, 2));
-        } elseif (1 === preg_match('/^0\\d+$/', $value)) {
-            $value = octdec(substr($value, 1));
-        } elseif (1 === preg_match('/^\\d+\\.\\d*$/', $value)) {
-            $value = (float) $value;
-        } else {
+        // Strip PHP 7.4 underscorse separator before comparison
+        $value = str_replace('_', '', $node->getText());
+        if (1 === preg_match('/^[1-9][0-9]*$/', $value)) {
             $value = (int) $value;
+        } elseif (1 === preg_match('/^0[xX][0-9a-fA-F]+$/', $value)) {
+            $value = hexdec(substr($value, 2));
+        } elseif (1 === preg_match('/^0[0-7]+$/', $value)) {
+            $value = octdec(substr($value, 1));
+        } elseif (1 === preg_match('/^0[bB][01]+$/', $value)) {
+            $value = bindec(substr($value, 2));
+        } else {
+            $value = (float) $value;
         }
 
         return $this->symbolFactory->context(

--- a/tests/Integration/Core/Inference/SymbolContextResolverTest.php
+++ b/tests/Integration/Core/Inference/SymbolContextResolverTest.php
@@ -548,6 +548,33 @@ class SymbolContextResolverTest extends IntegrationTestCase
                 , [], ['type' => 'int', 'value' => 12, 'symbol_type' => Symbol::NUMBER],
                 ];
 
+        yield 'It returns type for octal integer' => [
+                <<<'EOT'
+                    <?php
+
+                    012<>;
+                    EOT
+                , [], ['type' => 'int', 'value' => 012, 'symbol_type' => Symbol::NUMBER],
+                ];
+
+        yield 'It returns type for hexadecimal integer' => [
+                <<<'EOT'
+                    <?php
+
+                    0x1A<>;
+                    EOT
+                , [], ['type' => 'int', 'value' => 0x1A, 'symbol_type' => Symbol::NUMBER],
+                ];
+
+        yield 'It returns type for binary integer' => [
+                <<<'EOT'
+                    <?php
+
+                    0b11<>;
+                    EOT
+                , [], ['type' => 'int', 'value' => 0b11, 'symbol_type' => Symbol::NUMBER],
+                ];
+
         yield 'It returns type for bool true' => [
                 <<<'EOT'
                     <?php


### PR DESCRIPTION
Example: https://github.com/laminas/laminas-form/blob/ed6c9722c2b3b3f8825b2ce626c8d0da29a72594/src/FormInterface.php#L13

Without this fix, on VIM I get this blocking error:

```console
E605: Exception not caught: Could not parse response from Phpactor: Vim(let):E491: json decode error at 'PHP Warning:  A non-numeric value encountered in ./.vim/plugged/phpactor/vendor/phpactor/worse-reflection/lib/Core/Inference/SymbolContextResolver.php on line 461
```